### PR TITLE
fix: preserve CBR encoding for MP3 re-encode

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -132,8 +132,6 @@ pub fn apply_gain_mp3_reencode(
         "libmp3lame".to_string(),
         "-b:a".to_string(),
         bitrate,
-        "-q:a".to_string(),
-        "0".to_string(), // Highest quality VBR
         temp_path
             .to_str()
             .ok_or_else(|| anyhow!("Invalid temp path"))?


### PR DESCRIPTION
Remove VBR quality option (`-q:a 0`) that was overriding the CBR bitrate setting (`-b:a`). This ensures CBR MP3 files remain CBR after processing.

## Problem
When re-encoding MP3 files, the `-q:a 0` option (VBR quality) was being passed alongside `-b:a` (CBR bitrate). In ffmpeg's libmp3lame, `-q:a` takes precedence, causing all re-encoded files to become VBR regardless of the original encoding.

## Solution
Remove the `-q:a 0` option so that `-b:a` is respected and CBR files remain CBR.

Fixes #6