### PR TITLE
feat: add CLI flags for scriptable, non-interactive usage (#29)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +143,52 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -299,6 +395,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,9 +421,11 @@ version = "1.7.3"
 dependencies = [
  "anyhow",
  "chrono",
+ "clap",
  "console",
  "csv",
  "dialoguer",
+ "glob",
  "indicatif",
  "mp3rgain",
  "rayon",
@@ -403,6 +507,12 @@ dependencies = [
  "unit-prefix",
  "web-time",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -505,6 +615,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "option-ext"
@@ -694,6 +810,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "symphonia"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +967,12 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,11 @@ categories = ["command-line-utilities", "multimedia::audio"]
 
 [dependencies]
 # CLI interaction
+clap = { version = "4.5", features = ["derive"] }
 dialoguer = "0.12"
 console = "0.16"
 indicatif = "0.18"
+glob = "0.3"
 
 # Data handling
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ cargo build --release
 
 ## Usage
 
+### Interactive Mode
+
+Run without arguments to use the guided workflow in the current directory:
+
 ```bash
 cd ~/Music/DJ-Tracks
 headroom
@@ -163,6 +167,36 @@ The tool will guide you through:
 3. Confirming lossless processing
 4. Optionally enabling MP3/AAC re-encoding
 5. Creating backups (recommended)
+
+### Scriptable Mode
+
+Pass paths, globs, or flags to run non-interactively (useful for pipelines and scripts):
+
+```bash
+# Analyze a directory without modifying anything
+headroom --analyze-only ~/Music/DJ-Tracks
+
+# Apply only lossless gain, with backup, save report to a specific path
+headroom --lossless --backup ./bak --report results.csv ./album/
+
+# Enable re-encoding as well
+headroom --lossless --reencode --backup ./bak ./album/
+
+# Operate on specific files
+headroom --lossless track1.mp3 track2.flac
+
+# Glob patterns
+headroom --lossless --no-report "./music/**/*.mp3"
+```
+
+**Non-interactive defaults** (when any flag or path is provided):
+- `--lossless` is **on** unless `--no-lossless`
+- `--reencode` is **off** unless `--reencode` is explicitly passed
+- `--backup` is **off** unless provided; bare `--backup` uses `<target>/backup`
+- CSV report is written unless `--no-report`; `--report PATH` sets a custom location
+- `--analyze-only` runs analysis + report only, skips processing
+
+Run `headroom --help` for the full flag reference.
 
 ## Output
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,75 @@
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Audio loudness analyzer and gain adjustment tool.
+///
+/// Run without arguments for interactive mode in the current directory.
+/// Provide paths or any flag to run in non-interactive (scriptable) mode.
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+pub struct Cli {
+    /// Files, directories, or glob patterns to process. Defaults to current directory.
+    pub paths: Vec<String>,
+
+    /// Apply lossless gain adjustment (default in non-interactive mode)
+    #[arg(long, conflicts_with = "no_lossless")]
+    pub lossless: bool,
+
+    /// Skip lossless gain adjustment
+    #[arg(long)]
+    pub no_lossless: bool,
+
+    /// Apply re-encoding for MP3/AAC files needing precise gain
+    #[arg(long, conflicts_with = "no_reencode")]
+    pub reencode: bool,
+
+    /// Skip re-encoding (default in non-interactive mode)
+    #[arg(long)]
+    pub no_reencode: bool,
+
+    /// Create backup before processing (optional DIR; default: <target>/backup)
+    #[arg(long, value_name = "DIR", num_args = 0..=1, default_missing_value = "")]
+    pub backup: Option<PathBuf>,
+
+    /// Generate CSV report at PATH (default: <target>/headroom_report_<timestamp>.csv)
+    #[arg(long, value_name = "PATH", num_args = 0..=1, default_missing_value = "", conflicts_with = "no_report")]
+    pub report: Option<PathBuf>,
+
+    /// Skip CSV report
+    #[arg(long)]
+    pub no_report: bool,
+
+    /// Analyze files only, do not modify anything
+    #[arg(long)]
+    pub analyze_only: bool,
+}
+
+impl Cli {
+    /// Returns true if any non-interactive option or path was provided.
+    pub fn is_non_interactive(&self) -> bool {
+        !self.paths.is_empty()
+            || self.lossless
+            || self.no_lossless
+            || self.reencode
+            || self.no_reencode
+            || self.backup.is_some()
+            || self.report.is_some()
+            || self.no_report
+            || self.analyze_only
+    }
+
+    /// Whether lossless processing is enabled in non-interactive mode (default: true).
+    pub fn lossless_enabled(&self) -> bool {
+        !self.no_lossless
+    }
+
+    /// Whether re-encode processing is enabled in non-interactive mode (default: false).
+    pub fn reencode_enabled(&self) -> bool {
+        self.reencode && !self.no_reencode
+    }
+
+    /// Whether CSV report should be generated in non-interactive mode (default: true).
+    pub fn report_enabled(&self) -> bool {
+        !self.no_report
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,22 +1,34 @@
 use anyhow::{Context, Result};
+use clap::Parser;
 use console::{style, Style};
 use dialoguer::{theme::ColorfulTheme, Confirm};
 use indicatif::{ProgressBar, ProgressStyle};
 use rayon::prelude::*;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use crate::analyzer::{self, AudioAnalysis, GainMethod};
+use crate::args::Cli;
 use crate::processor;
 use crate::report::{self, AnalysisSummary};
 use crate::scanner;
 
 pub fn run() -> Result<()> {
+    let cli = Cli::parse();
+
     print_banner();
 
     // Check ffmpeg
     analyzer::check_ffmpeg()?;
 
+    if cli.is_non_interactive() {
+        run_scriptable(&cli)
+    } else {
+        run_interactive()
+    }
+}
+
+fn run_interactive() -> Result<()> {
     // Use current directory
     let target_dir = std::env::current_dir().context("Failed to get current directory")?;
 
@@ -26,7 +38,7 @@ pub fn run() -> Result<()> {
         style(target_dir.display()).bold()
     );
 
-    // Scan for audio files (always includes MP3)
+    // Scan for audio files
     let files = scanner::scan_audio_files(&target_dir);
 
     if files.is_empty() {
@@ -68,7 +80,7 @@ pub fn run() -> Result<()> {
         .filter(|a| a.has_headroom())
         .collect();
 
-    let csv_path = report::generate_csv(&processable_analyses, &target_dir)?;
+    let csv_path = report::generate_csv(&processable_analyses, &target_dir, None)?;
     println!(
         "{} Report saved: {}",
         style("✓").green(),
@@ -121,7 +133,140 @@ pub fn run() -> Result<()> {
     // Process files
     process_files(&files_to_process, &target_dir, backup_dir.as_deref())?;
 
-    // Final summary
+    print_final_summary(&files_to_process);
+
+    Ok(())
+}
+
+fn run_scriptable(cli: &Cli) -> Result<()> {
+    // Resolve input paths (default: current dir)
+    let (files, base_dir) = if cli.paths.is_empty() {
+        let cwd = std::env::current_dir().context("Failed to get current directory")?;
+        (scanner::scan_audio_files(&cwd), cwd)
+    } else {
+        let files = scanner::resolve_inputs(&cli.paths)?;
+        let base = common_base_dir(&files)
+            .or_else(|| std::env::current_dir().ok())
+            .unwrap_or_else(|| PathBuf::from("."));
+        (files, base)
+    };
+
+    if files.is_empty() {
+        println!("{} No audio files matched.", style("⚠").yellow());
+        println!(
+            "  Supported formats: {}",
+            scanner::get_supported_extensions().join(", ")
+        );
+        return Ok(());
+    }
+
+    println!(
+        "{} Found {} audio files",
+        style("✓").green(),
+        style(files.len()).cyan()
+    );
+
+    let all_analyses = analyze_files(&files)?;
+
+    let summary = AnalysisSummary::from_analyses(&all_analyses);
+
+    if !summary.has_processable() {
+        println!(
+            "\n{} No files with enough headroom found.",
+            style("ℹ").blue()
+        );
+        return Ok(());
+    }
+
+    report::print_analysis_report(&all_analyses);
+
+    let processable_analyses: Vec<_> = all_analyses.iter().filter(|a| a.has_headroom()).collect();
+
+    // Report generation
+    if cli.report_enabled() {
+        let explicit_path = cli.report.as_ref().and_then(|p| {
+            if p.as_os_str().is_empty() {
+                None
+            } else {
+                Some(p.as_path())
+            }
+        });
+        let csv_path = report::generate_csv(&processable_analyses, &base_dir, explicit_path)?;
+        println!(
+            "{} Report saved: {}",
+            style("✓").green(),
+            csv_path.display()
+        );
+    }
+
+    if cli.analyze_only {
+        println!("{} Analyze-only mode; no files modified.", style("ℹ").blue());
+        return Ok(());
+    }
+
+    let lossless_on = cli.lossless_enabled();
+    let reencode_on = cli.reencode_enabled();
+
+    let files_to_process: Vec<_> = all_analyses
+        .iter()
+        .filter(|a| {
+            if !a.has_headroom() {
+                return false;
+            }
+            if a.requires_reencode() {
+                reencode_on
+            } else {
+                lossless_on
+            }
+        })
+        .collect();
+
+    if files_to_process.is_empty() {
+        println!("{} No files to process with current flags.", style("ℹ").blue());
+        return Ok(());
+    }
+
+    // Backup directory resolution
+    let backup_dir = if let Some(path) = &cli.backup {
+        let dir = if path.as_os_str().is_empty() {
+            processor::create_backup_dir(&base_dir)?
+        } else {
+            std::fs::create_dir_all(path).context("Failed to create backup directory")?;
+            path.clone()
+        };
+        println!("{} Backup directory: {}", style("✓").green(), dir.display());
+        Some(dir)
+    } else {
+        None
+    };
+
+    process_files(&files_to_process, &base_dir, backup_dir.as_deref())?;
+
+    print_final_summary(&files_to_process);
+
+    Ok(())
+}
+
+fn common_base_dir(files: &[PathBuf]) -> Option<PathBuf> {
+    let mut iter = files.iter().filter_map(|f| f.parent().map(Path::to_path_buf));
+    let first = iter.next()?;
+    let base = iter.fold(first, |acc, p| common_prefix(&acc, &p));
+    Some(base)
+}
+
+fn common_prefix(a: &Path, b: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for (x, y) in a.components().zip(b.components()) {
+        if x == y {
+            out.push(x);
+        } else {
+            break;
+        }
+    }
+    out
+}
+
+fn print_final_summary(files_to_process: &[&AudioAnalysis]) {
     println!(
         "\n{} Done! {} files processed.",
         style("✓").green().bold(),
@@ -143,8 +288,6 @@ pub fn run() -> Result<()> {
             println!("  {} {} {}", style("•").dim(), count, label);
         }
     }
-
-    Ok(())
 }
 
 fn prompt_lossless_processing(summary: &AnalysisSummary) -> Result<bool> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod analyzer;
+mod args;
 mod cli;
 mod processor;
 mod report;

--- a/src/report.rs
+++ b/src/report.rs
@@ -5,10 +5,23 @@ use std::path::Path;
 
 use crate::analyzer::{AudioAnalysis, GainMethod};
 
-pub fn generate_csv(analyses: &[&AudioAnalysis], output_dir: &Path) -> Result<std::path::PathBuf> {
-    let timestamp = Local::now().format("%Y%m%d_%H%M%S");
-    let filename = format!("headroom_report_{}.csv", timestamp);
-    let output_path = output_dir.join(&filename);
+pub fn generate_csv(
+    analyses: &[&AudioAnalysis],
+    output_dir: &Path,
+    explicit_path: Option<&Path>,
+) -> Result<std::path::PathBuf> {
+    let output_path = if let Some(p) = explicit_path {
+        if let Some(parent) = p.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent).context("Failed to create report directory")?;
+            }
+        }
+        p.to_path_buf()
+    } else {
+        let timestamp = Local::now().format("%Y%m%d_%H%M%S");
+        let filename = format!("headroom_report_{}.csv", timestamp);
+        output_dir.join(&filename)
+    };
 
     let mut writer = csv::Writer::from_path(&output_path).context("Failed to create CSV file")?;
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,3 +1,5 @@
+use anyhow::{anyhow, Result};
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
@@ -18,12 +20,74 @@ pub fn scan_audio_files(dir: &Path) -> Vec<PathBuf> {
             }
 
             // Check extension
-            has_extension(e.path(), LOSSLESS_EXTENSIONS)
-                || has_extension(e.path(), MP3_EXTENSIONS)
-                || has_extension(e.path(), AAC_EXTENSIONS)
+            is_supported_audio_file(e.path())
         })
         .map(|e| e.path().to_path_buf())
         .collect()
+}
+
+/// Resolve a list of input strings (file paths, directories, globs) into a
+/// deduplicated, sorted list of audio files.
+pub fn resolve_inputs(inputs: &[String]) -> Result<Vec<PathBuf>> {
+    let mut collected: BTreeSet<PathBuf> = BTreeSet::new();
+
+    for input in inputs {
+        let path = PathBuf::from(input);
+
+        if path.is_dir() {
+            for file in scan_audio_files(&path) {
+                collected.insert(file);
+            }
+            continue;
+        }
+
+        if path.is_file() {
+            if is_audio_candidate(&path) {
+                collected.insert(path);
+            }
+            continue;
+        }
+
+        // Treat as glob pattern (supports e.g. "*.mp3", "music/**/*.flac")
+        let mut matched_any = false;
+        for entry in glob::glob(input)
+            .map_err(|e| anyhow!("Invalid glob pattern '{}': {}", input, e))?
+        {
+            let p = entry.map_err(|e| anyhow!("Glob error for '{}': {}", input, e))?;
+            if p.is_dir() {
+                for file in scan_audio_files(&p) {
+                    collected.insert(file);
+                }
+                matched_any = true;
+            } else if p.is_file() && is_audio_candidate(&p) {
+                collected.insert(p);
+                matched_any = true;
+            }
+        }
+
+        if !matched_any {
+            return Err(anyhow!(
+                "No matching audio files for input: '{}'",
+                input
+            ));
+        }
+    }
+
+    Ok(collected.into_iter().collect())
+}
+
+fn is_audio_candidate(path: &Path) -> bool {
+    let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    if filename.starts_with("._") {
+        return false;
+    }
+    is_supported_audio_file(path)
+}
+
+fn is_supported_audio_file(path: &Path) -> bool {
+    has_extension(path, LOSSLESS_EXTENSIONS)
+        || has_extension(path, MP3_EXTENSIONS)
+        || has_extension(path, AAC_EXTENSIONS)
 }
 
 pub fn get_supported_extensions() -> Vec<&'static str> {


### PR DESCRIPTION
Closes #29.

## Summary
- Adds `clap`-based argument parsing so `headroom` can be driven from scripts/pipelines without the interactive prompts.
- Running `headroom` with no arguments keeps the existing interactive workflow untouched.
- Passing any path/glob/flag switches to non-interactive mode.

## New Flags
| Flag | Behavior |
|------|----------|
| `--lossless` / `--no-lossless` | Toggle lossless gain (default: **on** in scripted mode) |
| `--reencode` / `--no-reencode` | Toggle re-encoding (default: **off** in scripted mode) |
| `--backup [DIR]` | Create backup; bare `--backup` uses `<target>/backup` |
| `--report [PATH]` / `--no-report` | CSV report control; `--report PATH` sets a custom location |
| `--analyze-only` | Analyze + report only, no file modification |

Positional arguments accept files, directories, and glob patterns (deduplicated + sorted).

## Examples
```bash
# Analyze only
headroom --analyze-only ~/Music/DJ-Tracks

# Lossless gain with backup and custom report path
headroom --lossless --backup ./bak --report results.csv ./album/

# Include re-encoding
headroom --lossless --reencode --backup ./bak ./album/

# Specific files / glob
headroom --lossless track1.mp3 track2.flac
headroom --lossless --no-report "./music/**/*.mp3"
```

## Test plan
- [x] `cargo build --release`
- [x] `cargo test` (3 existing tests pass)
- [x] `cargo clippy --all-targets` clean
- [x] `--help` / `--version` render correctly
- [x] `--lossless --no-lossless` and `--report --no-report` error as conflicts
- [x] `--analyze-only` against a directory produces report + no modification
- [x] Glob pattern (`"*.wav"`) resolves correctly
- [x] `--backup DIR` creates the directory and backs up originals
- [ ] Run interactive mode locally (no flags) to confirm unchanged behavior