### PR TITLE
feat: add rbsort subcommand for Rekordbox playlist sorting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -379,7 +379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -553,6 +553,7 @@ dependencies = [
  "glob",
  "indicatif",
  "mp3rgain",
+ "quick-xml",
  "rayon",
  "serde",
  "serde_json",
@@ -1071,6 +1072,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,7 +1281,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1578,7 +1588,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2034,7 +2044,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ chrono = "0.4"
 # MP3/AAC lossless gain adjustment
 mp3rgain = { version = "2.6", default-features = false, features = ["aac"] }
 
+# XML parsing (rbsort subcommand)
+quick-xml = "0.40"
+
 # Update notification
 update-informer = { version = "1.2", default-features = false, features = ["github", "ureq", "rustls-tls"] }
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Rekordbox does not expose a "sort by Key AND BPM" option in its UI. `headroom rb
 
 ### Workflow
 
-1. **Set key display to Camelot** in Rekordbox: *Preferences > View > Display format of key > Camelot*.
+1. **Set key display to Alphanumeric (1A..12B notation)** in Rekordbox: *Preferences > View > Key display format > Alphanumeric*.
 2. **Export**: *File > Export Collection in xml format* → e.g. `~/Music/rekordbox/collection.xml`.
 3. **Run rbsort**:
    ```bash
@@ -253,7 +253,7 @@ Rekordbox does not expose a "sort by Key AND BPM" option in its UI. `headroom rb
      --playlist "Sets/Friday" \
      --output ~/Music/rekordbox/sorted.xml
    ```
-4. **Import the result back into Rekordbox**: *Preferences > Advanced > rekordbox xml > Imported Library* → select `sorted.xml`. A "rekordbox xml" tree appears in the left sidebar.
+4. **Import the result back into Rekordbox**: *Preferences > Advanced > Database > rekordbox xml > Imported Library* → select `sorted.xml`. A "rekordbox xml" tree appears in the left sidebar.
 5. **Drag** the new `Sets/Friday (Key+BPM)` playlist from the imported tree into your real collection.
 
 ### Flags
@@ -273,7 +273,7 @@ Rekordbox does not expose a "sort by Key AND BPM" option in its UI. `headroom rb
 
 ### Notes
 
-- Requires Camelot notation in the `Tonality` field. Non-Camelot values (e.g. `Am`, `C#`) are silently sorted last.
+- Requires the `Tonality` field to be exported as 1A..12B (Rekordbox's "Alphanumeric" key display format). Non-matching values (e.g. `Am`, `C#`) are silently sorted last.
 - Only `KeyType="0"` (TrackID-referenced) playlists are supported.
 - `rbsort` does **not** require ffmpeg — only the analyzer subcommand does.
 - The new playlist is appended inside the same `<PLAYLISTS>` ROOT NODE; the ROOT `Count` attribute is incremented automatically.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # headroom
 
-Audio loudness analyzer and gain adjustment tool for mastering and DJ workflows.
+A toolkit for Rekordbox DJ workflows: loudness normalization for CDJ export, plus a Rekordbox XML playlist sorter for harmonic mixing.
 
 ## What is this?
 
 **headroom** simulates the behavior of Rekordbox's Auto Gain feature, but with a key difference: it identifies files with available headroom (True Peak below the target ceiling) and applies gain adjustment **without using a limiter**.
 
 This tool is designed for DJs and producers who want to maximize loudness while preserving dynamics, ensuring tracks hit the optimal True Peak ceiling without clipping.
+
+**New in v2.0.0** — a companion `rbsort` subcommand sorts a Rekordbox playlist by **Camelot Key (1A→12B) then BPM ascending**, and appends the result as a new playlist to your `collection.xml`. Useful for harmonic mixing prep when the Rekordbox UI does not expose multi-column sort. See [Rekordbox Playlist Sorter](#rekordbox-playlist-sorter-rbsort).
 
 ## Key Features
 
@@ -18,6 +20,7 @@ This tool is designed for DJs and producers who want to maximize loudness while 
 - **No limiter**: Pure gain adjustment only — dynamics are preserved
 - **Interactive CLI**: Guided step-by-step process with two-stage confirmation
 - **Scriptable CLI**: Non-interactive mode for pipelines and CI (paths, globs, and flags)
+- **Rekordbox playlist sorter** *(v2.0+)*: `headroom rbsort` produces a new playlist sorted by Camelot Key then BPM
 
 ## Processing Methods
 
@@ -102,7 +105,7 @@ $ cd ~/Music/DJ-Tracks
 $ headroom
 
 ╭─────────────────────────────────────╮
-│          headroom v1.7.3            │
+│          headroom v2.0.0            │
 │   Audio Loudness Analyzer & Gain    │
 ╰─────────────────────────────────────╯
 
@@ -232,6 +235,48 @@ headroom --lossless --tp-split-bitrate ./album/
 - `--analyze-only` runs analysis + report only, skips processing
 
 Run `headroom --help` for the full flag reference.
+
+## Rekordbox Playlist Sorter (`rbsort`)
+
+*Added in v2.0.0.*
+
+Rekordbox does not expose a "sort by Key AND BPM" option in its UI. `headroom rbsort` reads your `collection.xml`, sorts a target playlist by **Camelot Key (1A → 12B) ascending** then **BPM ascending**, and appends the result as a new playlist node to the same XML. The original playlist is left untouched.
+
+### Workflow
+
+1. **Set key display to Camelot** in Rekordbox: *Preferences > View > Display format of key > Camelot*.
+2. **Export**: *File > Export Collection in xml format* → e.g. `~/Music/rekordbox/collection.xml`.
+3. **Run rbsort**:
+   ```bash
+   headroom rbsort \
+     --xml ~/Music/rekordbox/collection.xml \
+     --playlist "Sets/Friday" \
+     --output ~/Music/rekordbox/sorted.xml
+   ```
+4. **Import the result back into Rekordbox**: *Preferences > Advanced > rekordbox xml > Imported Library* → select `sorted.xml`. A "rekordbox xml" tree appears in the left sidebar.
+5. **Drag** the new `Sets/Friday (Key+BPM)` playlist from the imported tree into your real collection.
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--xml <PATH>` | Path to `collection.xml` (required) |
+| `--playlist <PATH>` | Source playlist path, '/'-separated (e.g. `"Folder/MyPlaylist"`) |
+| `--output <PATH>` (`-o`) | Output XML path (required) |
+| `--name <NAME>` | Name for the new sorted playlist. Default: `<source> (Key+BPM)` |
+
+### Sort rules
+
+- **Primary**: Camelot Key ascending — `1A → 1B → 2A → 2B → … → 12A → 12B`
+- **Secondary**: BPM ascending within each key group
+- Tracks with no Camelot key sort **after** all known keys; within a key group, tracks with BPM 0 / unanalyzed sort last
+
+### Notes
+
+- Requires Camelot notation in the `Tonality` field. Non-Camelot values (e.g. `Am`, `C#`) are silently sorted last.
+- Only `KeyType="0"` (TrackID-referenced) playlists are supported.
+- `rbsort` does **not** require ffmpeg — only the analyzer subcommand does.
+- The new playlist is appended inside the same `<PLAYLISTS>` ROOT NODE; the ROOT `Count` attribute is incremented automatically.
 
 ## Output
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ Run `headroom --help` for the full flag reference.
 
 Rekordbox does not expose a "sort by Key AND BPM" option in its UI. `headroom rbsort` reads your `collection.xml`, sorts a target playlist by **Camelot Key (1A → 12B) ascending** then **BPM ascending**, and appends the result as a new playlist node to the same XML. The original playlist is left untouched.
 
+This is the same idea as headroom's analyzer applied to playlist order: Rekordbox's software-only features (Auto Gain, multi-column sort) don't follow your tracks to the CDJ. `rbsort` bakes Key+BPM order into the playlist itself — so when you export to USB in Rekordbox's EXPORT mode, the CDJ plays the set in that exact order with no on-deck reordering.
+
 ### Workflow
 
 1. **Set key display to Alphanumeric (1A..12B notation)** in Rekordbox: *Preferences > View > Key display format > Alphanumeric*.
@@ -256,7 +258,8 @@ Rekordbox does not expose a "sort by Key AND BPM" option in its UI. `headroom rb
 4. **Point Rekordbox at the output XML**: *Preferences > Advanced > Database > rekordbox xml > Imported Library* → select `sorted.xml`, then **restart Rekordbox** (Rekordbox only re-reads the XML on startup).
 5. **Open the `rekordbox xml` tree** in the left sidebar. It is a *separate* tree from your main library — switch to it from the **sidebar icon column** on the far left (the icon labeled `rekordbox xml`). Inside you'll find `rekordbox xml > Playlists > Sets/Friday (Key+BPM)`.
 6. **Verify the sort** by clicking the new playlist — tracks should run `1A` (lowest BPM) → `1B` → `2A` → … → `12B` (highest BPM).
-7. **Drag** the sorted playlist from the `rekordbox xml` tree into your main `Playlists` collection to use it in your sets. Your original playlist (still in `Playlists`) is unchanged.
+7. **Drag** the sorted playlist from the `rekordbox xml` tree into your main `Playlists` collection. Your original playlist (still in `Playlists`) is unchanged.
+8. **Export to USB for CDJ**: switch Rekordbox to *EXPORT* mode (top-left dropdown), plug in your USB / SD, then **right-click the playlist → Export Playlist**. CDJs read tracks in playlist order by default — your Key+BPM sort plays back on the deck in that exact order.
 
 > The sorted result lives **only** inside the `rekordbox xml` tree, not in your main `Playlists`. If you only see the original (unsorted) playlist, you're looking at the local library — switch sidebar trees.
 

--- a/README.md
+++ b/README.md
@@ -253,8 +253,12 @@ Rekordbox does not expose a "sort by Key AND BPM" option in its UI. `headroom rb
      --playlist "Sets/Friday" \
      --output ~/Music/rekordbox/sorted.xml
    ```
-4. **Import the result back into Rekordbox**: *Preferences > Advanced > Database > rekordbox xml > Imported Library* → select `sorted.xml`. A "rekordbox xml" tree appears in the left sidebar.
-5. **Drag** the new `Sets/Friday (Key+BPM)` playlist from the imported tree into your real collection.
+4. **Point Rekordbox at the output XML**: *Preferences > Advanced > Database > rekordbox xml > Imported Library* → select `sorted.xml`, then **restart Rekordbox** (Rekordbox only re-reads the XML on startup).
+5. **Open the `rekordbox xml` tree** in the left sidebar. It is a *separate* tree from your main library — switch to it from the **sidebar icon column** on the far left (the icon labeled `rekordbox xml`). Inside you'll find `rekordbox xml > Playlists > Sets/Friday (Key+BPM)`.
+6. **Verify the sort** by clicking the new playlist — tracks should run `1A` (lowest BPM) → `1B` → `2A` → … → `12B` (highest BPM).
+7. **Drag** the sorted playlist from the `rekordbox xml` tree into your main `Playlists` collection to use it in your sets. Your original playlist (still in `Playlists`) is unchanged.
+
+> The sorted result lives **only** inside the `rekordbox xml` tree, not in your main `Playlists`. If you only see the original (unsorted) playlist, you're looking at the local library — switch sidebar trees.
 
 ### Flags
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
 
 use crate::analyzer::{
@@ -12,6 +12,9 @@ use crate::analyzer::{
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Command>,
+
     /// Files, directories, or glob patterns to process. Defaults to current directory.
     pub paths: Vec<String>,
 
@@ -106,4 +109,29 @@ impl Cli {
     pub fn report_enabled(&self) -> bool {
         !self.no_report
     }
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Sort a Rekordbox playlist by Camelot Key then BPM, output as a new XML playlist.
+    Rbsort(RbsortArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct RbsortArgs {
+    /// Path to rekordbox collection.xml (File > Export Collection in xml format)
+    #[arg(long, value_name = "PATH")]
+    pub xml: PathBuf,
+
+    /// Source playlist path, '/'-separated (e.g., "Folder/MyPlaylist")
+    #[arg(long, value_name = "PATH")]
+    pub playlist: String,
+
+    /// Output XML path
+    #[arg(long, short, value_name = "PATH")]
+    pub output: PathBuf,
+
+    /// Name for the new sorted playlist (default: "<source> (Key+BPM)")
+    #[arg(long, value_name = "NAME")]
+    pub name: Option<String>,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,14 +7,19 @@ use rayon::prelude::*;
 use std::path::{Path, PathBuf};
 
 use crate::analyzer::{self, AudioAnalysis, GainMethod, TpTargetMode};
-use crate::args::Cli;
+use crate::args::{Cli, Command};
 use crate::processor;
+use crate::rbsort;
 use crate::report::{self, AnalysisSummary};
 use crate::scanner;
 use crate::updater;
 
 pub fn run() -> Result<()> {
     let cli = Cli::parse();
+
+    if let Some(Command::Rbsort(args)) = &cli.command {
+        return rbsort::run(args);
+    }
 
     print_banner();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod analyzer;
 mod args;
 mod cli;
 mod processor;
+mod rbsort;
 mod report;
 mod scanner;
 mod updater;

--- a/src/rbsort/camelot.rs
+++ b/src/rbsort/camelot.rs
@@ -1,0 +1,62 @@
+/// Parse a Camelot key string (e.g., "1A", "12B") into a sort index 0..=23.
+///
+/// Order: 1A=0, 1B=1, 2A=2, 2B=3, ..., 12A=22, 12B=23.
+/// Returns `None` for empty input or non-Camelot notation.
+pub fn parse_camelot(s: &str) -> Option<u8> {
+    let s = s.trim();
+    if s.len() < 2 || s.len() > 3 {
+        return None;
+    }
+    let (num_part, letter_part) = s.split_at(s.len() - 1);
+    let num: u8 = num_part.parse().ok()?;
+    if !(1..=12).contains(&num) {
+        return None;
+    }
+    let letter = match letter_part {
+        "A" | "a" => 0u8,
+        "B" | "b" => 1u8,
+        _ => return None,
+    };
+    Some((num - 1) * 2 + letter)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_valid_camelot() {
+        assert_eq!(parse_camelot("1A"), Some(0));
+        assert_eq!(parse_camelot("1B"), Some(1));
+        assert_eq!(parse_camelot("2A"), Some(2));
+        assert_eq!(parse_camelot("12A"), Some(22));
+        assert_eq!(parse_camelot("12B"), Some(23));
+        assert_eq!(parse_camelot(" 1a "), Some(0));
+    }
+
+    #[test]
+    fn rejects_invalid() {
+        assert_eq!(parse_camelot(""), None);
+        assert_eq!(parse_camelot("0A"), None);
+        assert_eq!(parse_camelot("13A"), None);
+        assert_eq!(parse_camelot("1C"), None);
+        assert_eq!(parse_camelot("Am"), None);
+        assert_eq!(parse_camelot("C#"), None);
+        assert_eq!(parse_camelot("100A"), None);
+    }
+
+    #[test]
+    fn ordering_is_monotonic() {
+        let order = [
+            "1A", "1B", "2A", "2B", "3A", "3B", "4A", "4B", "5A", "5B", "6A", "6B", "7A", "7B",
+            "8A", "8B", "9A", "9B", "10A", "10B", "11A", "11B", "12A", "12B",
+        ];
+        let mut prev = -1i16;
+        for k in order {
+            let idx = parse_camelot(k).unwrap() as i16;
+            assert!(idx > prev, "{k} should come after previous");
+            prev = idx;
+        }
+        assert_eq!(prev, 23);
+    }
+}

--- a/src/rbsort/mod.rs
+++ b/src/rbsort/mod.rs
@@ -28,7 +28,7 @@ pub fn run(args: &RbsortArgs) -> Result<()> {
         args.output.display()
     );
     println!(
-        "  {} Import via Rekordbox: Preferences > Advanced > rekordbox xml",
+        "  {} Import via Rekordbox: Preferences > Advanced > Database > rekordbox xml",
         style("ℹ").blue()
     );
     Ok(())

--- a/src/rbsort/mod.rs
+++ b/src/rbsort/mod.rs
@@ -1,0 +1,42 @@
+mod camelot;
+mod xml;
+
+use anyhow::Result;
+use console::style;
+
+use crate::args::RbsortArgs;
+
+pub fn run(args: &RbsortArgs) -> Result<()> {
+    let target_path = split_playlist_path(&args.playlist);
+    if target_path.is_empty() {
+        anyhow::bail!("--playlist must not be empty");
+    }
+
+    let source_name = target_path.last().cloned().unwrap_or_default();
+    let new_name = args
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("{source_name} (Key+BPM)"));
+
+    let count = xml::sort_and_write(&args.xml, &args.output, &target_path, &new_name)?;
+
+    println!(
+        "{} Sorted {} tracks into '{}' → {}",
+        style("✓").green().bold(),
+        style(count).cyan(),
+        style(&new_name).bold(),
+        args.output.display()
+    );
+    println!(
+        "  {} Import via Rekordbox: Preferences > Advanced > rekordbox xml",
+        style("ℹ").blue()
+    );
+    Ok(())
+}
+
+fn split_playlist_path(s: &str) -> Vec<String> {
+    s.split('/')
+        .map(|p| p.trim().to_string())
+        .filter(|p| !p.is_empty())
+        .collect()
+}

--- a/src/rbsort/mod.rs
+++ b/src/rbsort/mod.rs
@@ -31,6 +31,10 @@ pub fn run(args: &RbsortArgs) -> Result<()> {
         "  {} Import via Rekordbox: Preferences > Advanced > Database > rekordbox xml",
         style("ℹ").blue()
     );
+    println!(
+        "  {} Restart Rekordbox, then open the 'rekordbox xml' tree in the left sidebar",
+        style("ℹ").blue()
+    );
     Ok(())
 }
 

--- a/src/rbsort/xml.rs
+++ b/src/rbsort/xml.rs
@@ -70,19 +70,16 @@ fn scan_xml(
                             }
                         }
                     }
+                    "TRACK" if in_collection => {
+                        record_collection_track(&e, &mut collection)?;
+                    }
                     _ => {}
                 }
             }
             Ok(Event::Empty(e)) => {
                 let name = std::str::from_utf8(e.name().as_ref())?.to_string();
                 if in_collection && name == "TRACK" {
-                    if let Some(id) = get_attr(&e, "TrackID")? {
-                        let tonality = get_attr(&e, "Tonality")?.unwrap_or_default();
-                        let bpm_str = get_attr(&e, "AverageBpm")?.unwrap_or_default();
-                        let camelot = parse_camelot(&tonality);
-                        let bpm = bpm_str.parse::<f64>().ok().filter(|v| *v > 0.0);
-                        collection.insert(id, TrackMeta { camelot, bpm });
-                    }
+                    record_collection_track(&e, &mut collection)?;
                 } else if in_target && name == "TRACK" {
                     if let Some(k) = get_attr(&e, "Key")? {
                         tracks.push(k);
@@ -132,6 +129,20 @@ fn scan_xml(
     }
 
     Ok((collection, tracks))
+}
+
+fn record_collection_track(
+    e: &BytesStart,
+    collection: &mut HashMap<String, TrackMeta>,
+) -> Result<()> {
+    if let Some(id) = get_attr(e, "TrackID")? {
+        let tonality = get_attr(e, "Tonality")?.unwrap_or_default();
+        let bpm_str = get_attr(e, "AverageBpm")?.unwrap_or_default();
+        let camelot = parse_camelot(&tonality);
+        let bpm = bpm_str.parse::<f64>().ok().filter(|v| *v > 0.0);
+        collection.insert(id, TrackMeta { camelot, bpm });
+    }
+    Ok(())
 }
 
 fn get_attr(e: &BytesStart, name: &str) -> Result<Option<String>> {
@@ -371,5 +382,42 @@ mod tests {
     fn missing_playlist_errors() {
         let result = scan_xml(SAMPLE_XML.as_bytes(), &["Nope".to_string()]);
         assert!(result.is_err());
+    }
+
+    // Real Rekordbox exports wrap each COLLECTION <TRACK> with child elements
+    // (TEMPO, POSITION_MARK). quick-xml then yields Event::Start, not
+    // Event::Empty — so the scanner must read attributes from both.
+    const NESTED_TRACK_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<DJ_PLAYLISTS Version="1.0.0">
+  <COLLECTION Entries="2">
+    <TRACK TrackID="1" Name="Slow" AverageBpm="120.00" Tonality="1A">
+      <TEMPO Inizio="0.025" Bpm="120.00" Metro="4/4" Battito="1"/>
+      <POSITION_MARK Name="" Type="0" Start="0.025" Num="-1"/>
+    </TRACK>
+    <TRACK TrackID="2" Name="Fast" AverageBpm="128.00" Tonality="1A">
+      <TEMPO Inizio="0.010" Bpm="128.00" Metro="4/4" Battito="1"/>
+    </TRACK>
+  </COLLECTION>
+  <PLAYLISTS>
+    <NODE Type="0" Name="ROOT" Count="1">
+      <NODE Name="MyList" Type="1" KeyType="0" Entries="2">
+        <TRACK Key="2"/>
+        <TRACK Key="1"/>
+      </NODE>
+    </NODE>
+  </PLAYLISTS>
+</DJ_PLAYLISTS>
+"#;
+
+    #[test]
+    fn scans_collection_tracks_with_children() {
+        let (col, ids) = scan_xml(NESTED_TRACK_XML.as_bytes(), &["MyList".to_string()]).unwrap();
+        assert_eq!(ids, vec!["2", "1"]);
+        assert_eq!(col.get("1").and_then(|m| m.camelot), parse_camelot("1A"));
+        assert_eq!(col.get("1").and_then(|m| m.bpm), Some(120.0));
+        assert_eq!(col.get("2").and_then(|m| m.camelot), parse_camelot("1A"));
+        assert_eq!(col.get("2").and_then(|m| m.bpm), Some(128.0));
+        let sorted = sort_tracks(&ids, &col);
+        assert_eq!(sorted, vec!["1", "2"]); // 120 BPM before 128 within 1A
     }
 }

--- a/src/rbsort/xml.rs
+++ b/src/rbsort/xml.rs
@@ -1,0 +1,375 @@
+use anyhow::{bail, Context, Result};
+use quick_xml::events::{BytesEnd, BytesStart, Event};
+use quick_xml::reader::Reader;
+use quick_xml::writer::Writer;
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::Path;
+
+use super::camelot::parse_camelot;
+
+#[derive(Debug, Clone, Default)]
+struct TrackMeta {
+    camelot: Option<u8>,
+    bpm: Option<f64>,
+}
+
+pub fn sort_and_write(
+    input: &Path,
+    output: &Path,
+    target_path: &[String],
+    new_name: &str,
+) -> Result<usize> {
+    let xml_data = std::fs::read(input)
+        .with_context(|| format!("Failed to read {}", input.display()))?;
+
+    let (collection, playlist_track_ids) = scan_xml(&xml_data, target_path)?;
+    let sorted = sort_tracks(&playlist_track_ids, &collection);
+    let count = sorted.len();
+
+    let output_bytes = rewrite_xml(&xml_data, &sorted, new_name)?;
+    std::fs::write(output, output_bytes)
+        .with_context(|| format!("Failed to write {}", output.display()))?;
+
+    Ok(count)
+}
+
+fn scan_xml(
+    xml_data: &[u8],
+    target_path: &[String],
+) -> Result<(HashMap<String, TrackMeta>, Vec<String>)> {
+    let mut reader = Reader::from_reader(Cursor::new(xml_data));
+    reader.config_mut().trim_text(false);
+
+    let mut buf = Vec::new();
+    let mut in_collection = false;
+    let mut in_playlists = false;
+    let mut path_stack: Vec<String> = Vec::new();
+    let mut in_target = false;
+    let mut found = false;
+    let mut collection: HashMap<String, TrackMeta> = HashMap::new();
+    let mut tracks: Vec<String> = Vec::new();
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Eof) => break,
+            Ok(Event::Start(e)) => {
+                let name = std::str::from_utf8(e.name().as_ref())?.to_string();
+                match name.as_str() {
+                    "COLLECTION" => in_collection = true,
+                    "PLAYLISTS" => in_playlists = true,
+                    "NODE" if in_playlists => {
+                        let n = get_attr(&e, "Name")?.unwrap_or_default();
+                        let t = get_attr(&e, "Type")?.unwrap_or_default();
+                        path_stack.push(n);
+                        if t == "1" && path_stack.len() > 1 {
+                            let user_path = &path_stack[1..];
+                            if user_path == target_path {
+                                in_target = true;
+                                found = true;
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Ok(Event::Empty(e)) => {
+                let name = std::str::from_utf8(e.name().as_ref())?.to_string();
+                if in_collection && name == "TRACK" {
+                    if let Some(id) = get_attr(&e, "TrackID")? {
+                        let tonality = get_attr(&e, "Tonality")?.unwrap_or_default();
+                        let bpm_str = get_attr(&e, "AverageBpm")?.unwrap_or_default();
+                        let camelot = parse_camelot(&tonality);
+                        let bpm = bpm_str.parse::<f64>().ok().filter(|v| *v > 0.0);
+                        collection.insert(id, TrackMeta { camelot, bpm });
+                    }
+                } else if in_target && name == "TRACK" {
+                    if let Some(k) = get_attr(&e, "Key")? {
+                        tracks.push(k);
+                    }
+                } else if in_playlists && name == "NODE" {
+                    let n = get_attr(&e, "Name")?.unwrap_or_default();
+                    let t = get_attr(&e, "Type")?.unwrap_or_default();
+                    path_stack.push(n);
+                    if t == "1" && path_stack.len() > 1 {
+                        let user_path = &path_stack[1..];
+                        if user_path == target_path {
+                            found = true;
+                        }
+                    }
+                    path_stack.pop();
+                }
+            }
+            Ok(Event::End(e)) => {
+                let name = std::str::from_utf8(e.name().as_ref())?.to_string();
+                match name.as_str() {
+                    "COLLECTION" => in_collection = false,
+                    "PLAYLISTS" => in_playlists = false,
+                    "NODE" if in_playlists => {
+                        if in_target && path_stack.len() > 1 {
+                            let user_path = &path_stack[1..];
+                            if user_path == target_path {
+                                in_target = false;
+                            }
+                        }
+                        path_stack.pop();
+                    }
+                    _ => {}
+                }
+            }
+            Err(e) => bail!(
+                "XML parse error at byte {}: {}",
+                reader.buffer_position(),
+                e
+            ),
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    if !found {
+        bail!("Playlist not found: {}", target_path.join("/"));
+    }
+
+    Ok((collection, tracks))
+}
+
+fn get_attr(e: &BytesStart, name: &str) -> Result<Option<String>> {
+    for attr in e.attributes() {
+        let attr = attr?;
+        if attr.key.as_ref() == name.as_bytes() {
+            #[allow(deprecated)]
+            let val = attr.unescape_value()?.into_owned();
+            return Ok(Some(val));
+        }
+    }
+    Ok(None)
+}
+
+fn sort_tracks(track_ids: &[String], collection: &HashMap<String, TrackMeta>) -> Vec<String> {
+    let mut items: Vec<(&String, Option<u8>, Option<f64>)> = track_ids
+        .iter()
+        .map(|tid| {
+            let m = collection.get(tid).cloned().unwrap_or_default();
+            (tid, m.camelot, m.bpm)
+        })
+        .collect();
+
+    items.sort_by(|a, b| {
+        let cmp_key = match (a.1, b.1) {
+            (Some(x), Some(y)) => x.cmp(&y),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+        };
+        if cmp_key != std::cmp::Ordering::Equal {
+            return cmp_key;
+        }
+        match (a.2, b.2) {
+            (Some(x), Some(y)) => x.partial_cmp(&y).unwrap_or(std::cmp::Ordering::Equal),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+        }
+    });
+
+    items.into_iter().map(|(t, _, _)| t.clone()).collect()
+}
+
+fn rewrite_xml(xml_data: &[u8], sorted_ids: &[String], new_name: &str) -> Result<Vec<u8>> {
+    let mut reader = Reader::from_reader(Cursor::new(xml_data));
+    reader.config_mut().trim_text(false);
+
+    let mut output: Vec<u8> = Vec::with_capacity(xml_data.len() + 4096);
+    {
+        let mut writer = Writer::new(Cursor::new(&mut output));
+        let mut buf = Vec::new();
+        let mut in_playlists = false;
+        let mut playlists_depth: i32 = 0;
+
+        loop {
+            match reader.read_event_into(&mut buf) {
+                Ok(Event::Eof) => break,
+                Ok(Event::Start(e)) => {
+                    let name = std::str::from_utf8(e.name().as_ref())?.to_string();
+                    if name == "PLAYLISTS" {
+                        in_playlists = true;
+                        playlists_depth = 0;
+                        writer.write_event(Event::Start(e.into_owned()))?;
+                    } else if in_playlists && name == "NODE" {
+                        playlists_depth += 1;
+                        if playlists_depth == 1 {
+                            let mut new_start = BytesStart::new("NODE");
+                            for attr in e.attributes() {
+                                let attr = attr?;
+                                if attr.key.as_ref() == b"Count" {
+                                    let val: usize = std::str::from_utf8(&attr.value)?
+                                        .trim()
+                                        .parse()
+                                        .unwrap_or(0);
+                                    let new_val = (val + 1).to_string();
+                                    new_start.push_attribute(("Count", new_val.as_str()));
+                                } else {
+                                    new_start.push_attribute(attr);
+                                }
+                            }
+                            writer.write_event(Event::Start(new_start))?;
+                        } else {
+                            writer.write_event(Event::Start(e.into_owned()))?;
+                        }
+                    } else {
+                        writer.write_event(Event::Start(e.into_owned()))?;
+                    }
+                }
+                Ok(Event::End(e)) => {
+                    let name = std::str::from_utf8(e.name().as_ref())?.to_string();
+                    if in_playlists && name == "NODE" {
+                        if playlists_depth == 1 {
+                            emit_new_playlist(&mut writer, new_name, sorted_ids)?;
+                        }
+                        playlists_depth -= 1;
+                        writer.write_event(Event::End(e.into_owned()))?;
+                    } else if name == "PLAYLISTS" {
+                        in_playlists = false;
+                        writer.write_event(Event::End(e.into_owned()))?;
+                    } else {
+                        writer.write_event(Event::End(e.into_owned()))?;
+                    }
+                }
+                Ok(other) => {
+                    writer.write_event(other)?;
+                }
+                Err(e) => bail!("XML rewrite error: {}", e),
+            }
+            buf.clear();
+        }
+    }
+    Ok(output)
+}
+
+fn emit_new_playlist<W: std::io::Write>(
+    writer: &mut Writer<W>,
+    name: &str,
+    track_ids: &[String],
+) -> Result<()> {
+    let entries = track_ids.len().to_string();
+    let mut node = BytesStart::new("NODE");
+    node.push_attribute(("Name", name));
+    node.push_attribute(("Type", "1"));
+    node.push_attribute(("KeyType", "0"));
+    node.push_attribute(("Entries", entries.as_str()));
+    writer.write_event(Event::Start(node))?;
+
+    for tid in track_ids {
+        let mut track = BytesStart::new("TRACK");
+        track.push_attribute(("Key", tid.as_str()));
+        writer.write_event(Event::Empty(track))?;
+    }
+
+    writer.write_event(Event::End(BytesEnd::new("NODE")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sorts_by_camelot_then_bpm() {
+        let mut col = HashMap::new();
+        col.insert(
+            "a".into(),
+            TrackMeta {
+                camelot: parse_camelot("8A"),
+                bpm: Some(126.0),
+            },
+        );
+        col.insert(
+            "b".into(),
+            TrackMeta {
+                camelot: parse_camelot("8A"),
+                bpm: Some(124.0),
+            },
+        );
+        col.insert(
+            "c".into(),
+            TrackMeta {
+                camelot: parse_camelot("1A"),
+                bpm: Some(130.0),
+            },
+        );
+        col.insert(
+            "d".into(),
+            TrackMeta {
+                camelot: parse_camelot("12B"),
+                bpm: Some(120.0),
+            },
+        );
+        let input = vec!["a".into(), "b".into(), "c".into(), "d".into()];
+        let sorted = sort_tracks(&input, &col);
+        assert_eq!(sorted, vec!["c", "b", "a", "d"]);
+    }
+
+    #[test]
+    fn unknown_keys_go_last_within_known() {
+        let mut col = HashMap::new();
+        col.insert(
+            "a".into(),
+            TrackMeta {
+                camelot: parse_camelot("1A"),
+                bpm: Some(120.0),
+            },
+        );
+        col.insert(
+            "b".into(),
+            TrackMeta {
+                camelot: None,
+                bpm: Some(120.0),
+            },
+        );
+        let input = vec!["b".into(), "a".into()];
+        let sorted = sort_tracks(&input, &col);
+        assert_eq!(sorted, vec!["a", "b"]);
+    }
+
+    const SAMPLE_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<DJ_PLAYLISTS Version="1.0.0">
+  <COLLECTION Entries="3">
+    <TRACK TrackID="1" Name="Slow" AverageBpm="120.00" Tonality="1A"/>
+    <TRACK TrackID="2" Name="Fast" AverageBpm="128.00" Tonality="1A"/>
+    <TRACK TrackID="3" Name="Other" AverageBpm="124.00" Tonality="12B"/>
+  </COLLECTION>
+  <PLAYLISTS>
+    <NODE Type="0" Name="ROOT" Count="1">
+      <NODE Name="MyList" Type="1" KeyType="0" Entries="3">
+        <TRACK Key="2"/>
+        <TRACK Key="1"/>
+        <TRACK Key="3"/>
+      </NODE>
+    </NODE>
+  </PLAYLISTS>
+</DJ_PLAYLISTS>
+"#;
+
+    #[test]
+    fn full_roundtrip_inserts_sorted_playlist() {
+        let (col, ids) = scan_xml(SAMPLE_XML.as_bytes(), &["MyList".to_string()]).unwrap();
+        assert_eq!(ids, vec!["2", "1", "3"]);
+        let sorted = sort_tracks(&ids, &col);
+        assert_eq!(sorted, vec!["1", "2", "3"]);
+
+        let out = rewrite_xml(SAMPLE_XML.as_bytes(), &sorted, "MyList (Key+BPM)").unwrap();
+        let out_str = String::from_utf8(out).unwrap();
+        assert!(out_str.contains(r#"Name="MyList (Key+BPM)""#));
+        assert!(out_str.contains(r#"Entries="3""#));
+        assert!(out_str.contains(r#"Count="2""#)); // ROOT count incremented
+        // Original playlist still present
+        assert!(out_str.contains(r#"Name="MyList""#));
+    }
+
+    #[test]
+    fn missing_playlist_errors() {
+        let result = scan_xml(SAMPLE_XML.as_bytes(), &["Nope".to_string()]);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- New `headroom rbsort` subcommand sorts a Rekordbox playlist by **Camelot Key (1A→12B)** then **BPM ascending**, and appends the result as a new playlist node to the same XML.
- Motivates harmonic mixing prep when the native Rekordbox UI does not expose multi-column sort.
- Adds `quick-xml = "0.40"` dependency; no impact on existing analyzer flow.

## Usage

```bash
headroom rbsort \
  --xml <collection.xml> \
  --playlist "Folder/MyPlaylist" \
  --output <out.xml> \
  [--name "<custom name>"]
```

Default new playlist name: `<source> (Key+BPM)`.

## Behavior

- **Scan pass** reads `<COLLECTION>` (TrackID → Camelot+BPM) and the target playlist's track ID list.
- **Sort**: Camelot ascending → BPM ascending. Tracks with no Camelot key sort after all known keys; within a key group, tracks with no/0 BPM go last.
- **Rewrite pass** stream-copies the XML and injects a new `<NODE Type="1" KeyType="0">` inside the ROOT NODE just before its closing tag. The ROOT `Count` attribute is incremented by 1.
- Errors out with `Playlist not found: <path>` (exit=1) if the target playlist does not exist.
- `rbsort` does not require ffmpeg — subcommand dispatch short-circuits before the analyzer setup.

## Assumptions

- Rekordbox 6/7 collection.xml format (`<DJ_PLAYLISTS>` → `<COLLECTION>` + `<PLAYLISTS>` with ROOT NODE wrapper).
- `Tonality` is in **Camelot notation** (`1A`..`12B`). User must set Rekordbox key display to Camelot before exporting; non-Camelot values silently sort last.
- Playlist NODE uses `KeyType="0"` (TrackID reference).

## Files

- `src/rbsort/mod.rs` — entry point and user-facing messages
- `src/rbsort/camelot.rs` — `1A`..`12B` parser → sort index 0..=23
- `src/rbsort/xml.rs` — two-pass scan + rewrite via quick-xml
- `src/args.rs` — `Command::Rbsort(RbsortArgs)` added; flat CLI preserved
- `src/cli.rs` — subcommand branch before ffmpeg/banner/update-check
- `src/main.rs` — module wiring

## Test plan

- [ ] `cargo test --release` passes (10 tests; 6 new for rbsort)
- [ ] `headroom --help` shows the new `rbsort` subcommand
- [ ] `headroom rbsort --help` shows flag list
- [ ] Sort a small synthetic XML and confirm:
  - [ ] New playlist appears inside `<PLAYLISTS>/<NODE Name="ROOT">`
  - [ ] ROOT `Count` is incremented
  - [ ] Track order = Camelot ascending, then BPM ascending
  - [ ] Tracks with empty `Tonality` go to the end
- [ ] Export a real playlist from Rekordbox, run rbsort, import via Preferences > Advanced > rekordbox xml, and confirm the new playlist is visible and ordered correctly
- [ ] Existing analyzer flow unaffected: `headroom`, `headroom <path>`, `headroom --analyze-only`, etc. still work