### PR TITLE
Skip headroom-created backup dirs during scanning

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -246,8 +246,7 @@ fn run_scriptable(cli: &Cli, tp_mode: TpTargetMode) -> Result<()> {
         let dir = if path.as_os_str().is_empty() {
             processor::create_backup_dir(&base_dir)?
         } else {
-            std::fs::create_dir_all(path).context("Failed to create backup directory")?;
-            path.clone()
+            processor::ensure_backup_dir(path)?
         };
         println!("{} Backup directory: {}", style("✓").green(), dir.display());
         Some(dir)

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -6,9 +6,20 @@ use std::process::Command;
 use crate::analyzer::{AudioAnalysis, GainMethod};
 
 pub fn create_backup_dir(base_dir: &Path) -> Result<PathBuf> {
-    let backup_dir = base_dir.join("backup");
-    fs::create_dir_all(&backup_dir).context("Failed to create backup directory")?;
-    Ok(backup_dir)
+    ensure_backup_dir(&base_dir.join("backup"))
+}
+
+/// Create (if needed) and mark a backup directory. The marker file lets the
+/// scanner skip backup copies on subsequent runs (issue #45) without relying
+/// on magic directory names.
+pub fn ensure_backup_dir(backup_dir: &Path) -> Result<PathBuf> {
+    fs::create_dir_all(backup_dir).context("Failed to create backup directory")?;
+    let marker = backup_dir.join(crate::scanner::BACKUP_MARKER);
+    if !marker.exists() {
+        fs::write(&marker, "Created by headroom; this directory is skipped when scanning.\n")
+            .context("Failed to write backup marker file")?;
+    }
+    Ok(backup_dir.to_path_buf())
 }
 
 fn backup_file(file_path: &Path, base_dir: &Path, backup_dir: &Path) -> Result<PathBuf> {

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,19 +1,31 @@
 use anyhow::{anyhow, Result};
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
-use walkdir::WalkDir;
+use walkdir::{DirEntry, WalkDir};
 
 const LOSSLESS_EXTENSIONS: &[&str] = &["flac", "aiff", "aif", "wav"];
 const MP3_EXTENSIONS: &[&str] = &["mp3"];
 const AAC_EXTENSIONS: &[&str] = &["m4a", "aac", "mp4"];
 
+/// Marker file written into backup directories created by headroom.
+/// Directories containing it are skipped during recursive scans so backup
+/// copies are never re-analyzed and re-adjusted (issue #45).
+pub const BACKUP_MARKER: &str = ".headroom-backup";
+
 pub fn scan_audio_files(dir: &Path) -> Vec<PathBuf> {
     WalkDir::new(dir)
         .into_iter()
+        // depth 0 is the scan root itself: scanning a backup dir explicitly
+        // is intentional, so only skip marked dirs found during descent.
+        .filter_entry(|e| e.depth() == 0 || !is_backup_dir(e))
         .filter_map(|e| e.ok())
         .filter(|e| e.file_type().is_file() && is_audio_candidate(e.path()))
         .map(|e| e.path().to_path_buf())
         .collect()
+}
+
+fn is_backup_dir(entry: &DirEntry) -> bool {
+    entry.file_type().is_dir() && entry.path().join(BACKUP_MARKER).is_file()
 }
 
 /// Resolve a list of input strings (file paths, directories, globs) into a


### PR DESCRIPTION
## Summary

Fixes #45 — backup copies under `<target>/backup` were picked up by the recursive scan on subsequent runs and got analyzed and gain-adjusted, defeating the purpose of a backup.

## Approach

Marker-file based exclusion (avoids magic-name filtering of user folders):

- `create_backup_dir` / the new `ensure_backup_dir` write a `.headroom-backup` marker file into every backup directory headroom creates (default and `--backup <DIR>` custom paths alike)
- `scan_audio_files` skips any directory containing the marker during descent
- The scan root itself (depth 0) is exempt, so explicitly pointing headroom at a backup directory still works (e.g. when intentionally processing restored copies)

## Notes

- Backup directories created by older versions have no marker and are still scanned once; re-running with `--backup` re-marks the default location going forward
- Verified: with the marker present, `backup/a.mp3` is excluded from the scan; without it, both files are found

## Test plan

- `cargo build --release` / `cargo test` pass
- Manual smoke test with a marked and unmarked backup dir (1 vs 2 files found)