### PR TITLE
Move startup update check off the critical path

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,20 +23,26 @@ pub fn run() -> Result<()> {
 
     print_banner();
 
-    if !cli.no_update_check {
-        updater::check_and_notify();
-    }
+    // Runs in the background during analysis; the notification is printed
+    // last so the network call never delays startup (issue #46).
+    let update_check = (!cli.no_update_check).then(updater::spawn_check);
 
     analyzer::check_ffmpeg()?;
 
     let tp_mode = cli.tp_mode();
     print_tp_target_banner(tp_mode);
 
-    if cli.is_non_interactive() {
+    let result = if cli.is_non_interactive() {
         run_scriptable(&cli, tp_mode)
     } else {
         run_interactive(tp_mode)
+    };
+
+    if let Some(handle) = update_check {
+        updater::notify(handle);
     }
+
+    result
 }
 
 fn print_tp_target_banner(tp_mode: TpTargetMode) {

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,27 +1,29 @@
 use console::style;
+use std::thread::JoinHandle;
 use std::time::Duration;
 use update_informer::{registry, Check};
 
 const PKG_NAME: &str = "M-Igashi/headroom";
 const CHECK_INTERVAL: Duration = Duration::from_secs(60 * 60 * 24);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(3);
 
-pub fn check_and_notify() {
-    if std::env::var_os("HEADROOM_NO_UPDATE_CHECK").is_some() {
-        return;
-    }
+/// Start the version check on a background thread so a slow or offline
+/// network never stalls startup. The result is printed later via `notify`.
+pub fn spawn_check() -> JoinHandle<Option<String>> {
+    std::thread::spawn(check)
+}
 
-    let current = env!("CARGO_PKG_VERSION");
-    let informer = update_informer::new(registry::GitHub, PKG_NAME, current).interval(CHECK_INTERVAL);
-
-    let Ok(Some(new_version)) = informer.check_version() else {
+/// Print the update notification (if any) from a previously spawned check.
+pub fn notify(handle: JoinHandle<Option<String>>) {
+    let Ok(Some(new_version)) = handle.join() else {
         return;
     };
 
-    let new_str = new_version.to_string();
-    let stripped = new_str.strip_prefix('v').unwrap_or(&new_str);
+    let current = env!("CARGO_PKG_VERSION");
+    let stripped = new_version.strip_prefix('v').unwrap_or(&new_version);
 
     println!(
-        "{} Update available: {} → {}",
+        "\n{} Update available: {} → {}",
         style("↑").yellow().bold(),
         style(format!("v{}", current)).dim(),
         style(format!("v{}", stripped)).green().bold()
@@ -31,6 +33,18 @@ pub fn check_and_notify() {
         println!("   {}", style(line).dim());
     }
     println!();
+}
+
+fn check() -> Option<String> {
+    if std::env::var_os("HEADROOM_NO_UPDATE_CHECK").is_some() {
+        return None;
+    }
+
+    let informer = update_informer::new(registry::GitHub, PKG_NAME, env!("CARGO_PKG_VERSION"))
+        .interval(CHECK_INTERVAL)
+        .timeout(REQUEST_TIMEOUT);
+
+    informer.check_version().ok().flatten().map(|v| v.to_string())
 }
 
 fn update_commands() -> Vec<String> {


### PR DESCRIPTION
## Summary

Fixes #46 — `updater::check_and_notify()` ran synchronously at startup, so on the first run (and once per day after the 24h cache expires) a slow or offline network could stall startup for several seconds before any analysis began.

## Changes

- `updater::check_and_notify` is split into `spawn_check()` (starts the check on a background thread at startup) and `notify(handle)` (joins and prints after the run completes)
- The notification now prints **after** analysis/processing, so the upgrade hint is the last thing the user sees instead of scrolling away
- Explicit 3-second request timeout on the informer, bounding the worst-case join wait at the end
- No output is produced from the background thread itself, so there is no interleaving with the indicatif progress bars

## Test plan

- `cargo build --release` / `cargo test` pass
- Smoke-run with the check enabled: startup proceeds immediately, no stray output during analysis