### PR TITLE
Preserve original artwork format when applying gain

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -190,6 +190,9 @@ fn apply_gain_ffmpeg(file_path: &Path, gain_db: f64) -> Result<()> {
     cmd.args(["-y", "-i"])
         .arg(file_path)
         .args(["-af", &volume_arg])
+        // Stream-copy embedded artwork. Without this, muxer defaults re-encode
+        // a JPEG cover to PNG and inflate the file (issue #77).
+        .args(["-c:v", "copy"])
         .args(output_args(
             &extension.to_ascii_lowercase(),
             source.as_ref(),
@@ -276,10 +279,13 @@ fn apply_gain_reencode(
 
     for encoder in format.encoders() {
         // CBR-only: adding -q:a would force libmp3lame to VBR and override -b:a.
+        // -c:v copy keeps the original cover art bytes; the muxer defaults would
+        // re-encode it to PNG (MP3) or fail outright on h264 (M4A) — issue #77.
         let output = Command::new("ffmpeg")
             .args(["-y", "-i"])
             .arg(file_path)
             .args(["-af", &volume_arg, "-c:a", encoder, "-b:a", &bitrate])
+            .args(["-c:v", "copy"])
             .arg(&temp_path)
             .output()
             .with_context(|| format!("Failed to execute ffmpeg for {} re-encode", label))?;


### PR DESCRIPTION
Fixes #77.

## Problem

`baken headroom` re-encoded embedded cover art instead of copying it. ffmpeg's muxer defaults pick a video encoder when none is given:

- FLAC / MP3 / AIFF → PNG. A JPEG cover comes back out as PNG, inflating the file.
- M4A → h264, which the ipod muxer rejects (`Could not find tag for codec h264`), so the AAC re-encode path failed outright on any file with artwork.
- WAV is unaffected, since its muxer takes no video streams.

Measured on a 500×500 photo-like JPEG cover in a FLAC: 205 KB grew to 404 KB after a single gain pass.

## Fix

Pass `-c:v copy` in both ffmpeg gain paths: `apply_gain_ffmpeg` for lossless files, and `apply_gain_reencode` for the MP3/AAC re-encode fallback. The original picture bytes are carried through untouched.

## Verification

- FLAC / MP3 / AIFF / M4A round-trips: output artwork is byte-identical to the source JPEG (`cmp` against the extracted cover).
- End-to-end `baken headroom . --lossless --reencode` on a FLAC with a JPEG cover: the stream stays `mjpeg`, the extracted cover is byte-identical, and gain is applied.
- No-artwork sources still process fine in all five containers, with metadata intact.
- `cargo test`: 39 passed.

`cdjsafe` is unchanged. Its mjpeg / 500×500 artwork normalization is a deliberate CDJ-compatibility decision from #40, not a muxer default.